### PR TITLE
Add unit test for compat bug

### DIFF
--- a/vstruct/compat.py
+++ b/vstruct/compat.py
@@ -60,9 +60,9 @@ if version < (3,0,0):
             x = (x - u_maxes[size]) - 1
         return x
     
-    def slowparsebytes(bytes, offset, size, sign=False, bigend=False):
+    def slowparsebytes(bytes, offset, size, sign=False, byteorder='little'):
         ''' Stolen from vivisect/envi/bits.py to keep vstruct dependency free. '''
-        if bigend:
+        if byteorder == 'big':
             begin = offset
             inc = 1
         else:
@@ -84,8 +84,7 @@ if version < (3,0,0):
         Mostly for pulling immediates out of strings...
         """
         if size > 8:
-            bigend = byteorder == 'big'
-            return slowparsebytes(byts, off, size, sign=signed, bigend=bigend)
+            return slowparsebytes(byts, off, size, sign=signed, byteorder=byteorder)
 
         fmt = fmtchars.get( (size,byteorder,signed) )
         if fmt != None:

--- a/vstruct/compat.py
+++ b/vstruct/compat.py
@@ -60,7 +60,7 @@ if version < (3,0,0):
             x = (x - u_maxes[size]) - 1
         return x
     
-    def slowparsebytes(bytes, offset, size, sign=False, byteorder='little'):
+    def slowparsebytes(byts, offset, size, sign=False, byteorder='little'):
         ''' Stolen from vivisect/envi/bits.py to keep vstruct dependency free. '''
         if byteorder == 'big':
             begin = offset
@@ -73,7 +73,7 @@ if version < (3,0,0):
         ioff = 0
         for x in range(size):
             ret = ret << 8
-            ret |= ord(bytes[begin+ioff])
+            ret |= ord(byts[begin+ioff])
             ioff += inc
         if sign:
             ret = signed(ret, size)

--- a/vstruct/compat.py
+++ b/vstruct/compat.py
@@ -43,7 +43,8 @@ if version < (3,0,0):
         Mostly for pulling immediates out of strings...
         """
         if size > 8:
-            return slowparsebytes(bytes, offset, size, sign=sign, bigend=bigend)
+            bigend = byteorder == 'big'
+            return slowparsebytes(byts, off, size, sign=signed, bigend=bigend)
 
         fmt = fmtchars.get( (size,byteorder,signed) )
         if fmt != None:

--- a/vstruct/tests/test_compat.py
+++ b/vstruct/tests/test_compat.py
@@ -11,6 +11,9 @@ class CompatTest(unittest.TestCase):
 
         self.assertEqual( bytes2int(b'\xff\xff\xff\xff', 4, signed=True), -1 )
         self.assertEqual( bytes2int(b'\xff\xff\xff\xff', 4, signed=False), 0xffffffff )
+        
+        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff', 12, signed=True), -1 )
+        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff', 12, signed=False), 0xffffffff )
 
     def test_compat_i2b(self):
 

--- a/vstruct/tests/test_compat.py
+++ b/vstruct/tests/test_compat.py
@@ -12,8 +12,17 @@ class CompatTest(unittest.TestCase):
         self.assertEqual( bytes2int(b'\xff\xff\xff\xff', 4, signed=True), -1 )
         self.assertEqual( bytes2int(b'\xff\xff\xff\xff', 4, signed=False), 0xffffffff )
         
-        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff', 12, signed=True), -1 )
-        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff', 12, signed=False), 0xffffffff )
+        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff', 8, signed=True), -1 )
+        self.assertEqual( bytes2int(b'\xff\xff\xff\xff\xff\xff\xff\xff', 8, signed=False), 0xffffffffffffffff )
+        
+        bytes16 = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        self.assertEqual( bytes2int(bytes16, 16, signed=True), -1 )
+        self.assertEqual( bytes2int(bytes16, 16, byteorder='big', signed=True), -1 )
+        self.assertEqual( bytes2int(bytes16, 16), 0xffffffffffffffffffffffffffffffff )
+        
+        bytes16_2 = b'\xff\xff\xff\xff\xff\xff\xff\xff\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+        self.assertEqual( bytes2int(bytes16_2, 16, byteorder='big'), 0xfffffffffffffffff0f0f0f0f0f0f0f0 )
+        self.assertEqual( bytes2int(bytes16_2, 16), 0xf0f0f0f0f0f0f0f0ffffffffffffffff )
 
     def test_compat_i2b(self):
 
@@ -24,3 +33,6 @@ class CompatTest(unittest.TestCase):
 
         self.assertEqual( int2bytes(0x0080, 2, byteorder='big'), b'\x00\x80' )
         self.assertEqual( int2bytes(0x0080, 2, byteorder='little'), b'\x80\x00' )
+
+        self.assertEqual( int2bytes(0x008000800080008000800080, 12, byteorder='big'), b'\x00\x80\x00\x80\x00\x80\x00\x80\x00\x80\x00\x80' )
+        self.assertEqual( int2bytes(0x008000800080008000800080, 12, byteorder='little'), b'\x80\x00\x80\x00\x80\x00\x80\x00\x80\x00\x80\x00' )


### PR DESCRIPTION
Fixes bad kwarg values provided in py2.7 compay code when attempting to bytes2int bytes with size > 8.

Adds a unit test showing failure case.

The remaining fix here is to import `vivisect/envi/bits.py`, where `slowparsebytes` and other requisite bit-sy stuff lives, but I don't know if we want to copypasta the necessary code, or import that vivisect file.
